### PR TITLE
Add #111 Switch to lefthook for git hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ p*/**/LICENSE
 
 p*/**/node_modules/
 p*/**/logs/.turbo
+
+#non-pnpm lock files
+yarn.lock
+package-lock.json

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm run format && npm run lint && git add .

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,14 @@
+commit-msg:
+  commands:
+    commitlint:
+      run: npx commitlint --edit --color
+
+pre-commit:
+  parallel: true
+  commands:
+    format:
+      glob: "*.{css,html,json,less,md,scss,yaml,yml,ts,tsx}"
+      run: npx prettier --write --log-level error {staged_files} && git add {staged_files}
+    code:
+      glob: "*.{js,jsx,ts,tsx}"
+      run: npx eslint {staged_files} --fix && git add {staged_files}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "bump-version": "turbo run bump-version",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "format": "prettier --write \"**/*.{js,ts,tsx,md}\" --cache",
-    "prepare": "husky install",
+    "format:fix": "prettier --write \"**/*.{js,ts,tsx,md}\" --cache",
+    "format": "prettier --check .",
     "release": "turbo run release",
     "submodules:load": "git submodule update --init",
     "submodules:sync": "git submodule update --recursive --remote",
@@ -31,12 +31,12 @@
     "turbo": "1.7.3"
   },
   "devDependencies": {
-    "@commitlint/cli": "17.4.2",
-    "@commitlint/config-conventional": "17.4.2",
+    "@commitlint/cli": "^19.2.1",
+    "@commitlint/config-conventional": "^19.1.0",
     "@sliit-foss/eslint-config-internal": "workspace:*",
     "eslint": "8.33.0",
     "eslint-config-turbo": "0.0.7",
-    "husky": "8.0.3",
+    "lefthook": "^1.6.10",
     "nodemon": "2.0.21",
     "prettier": "2.8.3"
   },


### PR DESCRIPTION
This PR addresses this [issue](https://github.com/sliit-foss/npm-catalogue/issues/111).

Even though it is mentioned in the issue to use lint staged this PR sets them up using lefthook after a discussion with the maintainers.