### PR TITLE
Fix #111 Change lefthook linting command name

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -4,7 +4,7 @@ pre-commit:
     format:
       glob: "*.{css,html,json,less,md,scss,yaml,yml,js,jsx,ts,tsx}"
       run: npx prettier --write --cache --log-level error {staged_files} && git add {staged_files}
-    code:
+    lint:
       glob: "*.{js,jsx,ts,tsx}"
       run: npx eslint --cache {staged_files} --fix && git add {staged_files}
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-turbo": "0.0.7",
     "lefthook": "1.6.10",
     "nodemon": "2.0.21",
-    "prettier": "2.8.3"
+    "prettier": "3.2.5"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
- Rename lefthook linting command name from 'code' to 'lint'
- Update prettier version